### PR TITLE
Add more pytest tools to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dev-dependencies = [
     "pre-commit>=3.7.0",
     "pytest>=8.2.0",
     "pytest-cov>=5.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.12.0",
+    "hypothesis>=6.0.0",
 ]
 
 # Tool configurations


### PR DESCRIPTION
## Summary
- include pytest-asyncio, pytest-mock, and hypothesis in dev dependencies

## Testing
- `uv run pytest -q` *(fails: failed to fetch pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_686d84400ff0832fae16b4755f36cff7