### PR TITLE
Add CI workflow using uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Install dependencies
         run: uv sync
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: uv run pre-commit run --all-files
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: uv sync
+      - name: Run pre-commit
+        run: pre-commit run --all-files
+      - name: Run tests
+        run: uv run pytest


### PR DESCRIPTION
## Summary
- run CI on push and PR
- set up Python 3.10 and install dependencies with uv
- run `pre-commit` and `pytest`

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `uv run pytest` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d843cce7c832f8d047a79caf2feb6