### PR TITLE
Add Codex setup script

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install project dependencies and dev tools
+uv sync
+
+# Additional tools required for CI hooks
+uv pip install commitizen detect-secrets
+
+# Install project in editable mode (optional)
+uv pip install -e .


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install dev dependencies and CI tools

## Testing
- `pre-commit run --files .codex/setup.sh` *(fails: command not found)*
- `uv pip install pre-commit commitizen detect-secrets` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686d8556f260832fa579813795adfb68