### PR TITLE
Add format session for nox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This project uses `uv` for dependency management and `pre-commit` for code quali
 
 - Format code:
   ```bash
-  uv run pyink .
+  uv run nox -s format
   ```
 - Lint and auto-fix:
   ```bash
@@ -30,6 +30,10 @@ This project uses `uv` for dependency management and `pre-commit` for code quali
 - Run tests:
   ```bash
   uv run pytest
+  ```
+- Run all sessions:
+  ```bash
+  uv run nox -s all
   ```
 
 For new commits, run the hooks against staged files:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ uv sync
 uv run nox -s tests
 
 # Format code
-uv run pyink .
+uv run nox -s format
 
 # Lint code
 uv run nox -s lint
@@ -35,5 +35,5 @@ uv run nox -s lint
 uv run nox -s typecheck
 
 # Run everything
-uv run nox
+uv run nox -s all
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,6 +2,12 @@ import nox
 
 
 @nox.session
+def format(session: nox.Session) -> None:
+  """Format code using Pyink."""
+  session.run("uv", "run", "pyink", ".", external=True)
+
+
+@nox.session
 def lint(session: nox.Session) -> None:
   """Run Ruff to lint the project."""
   session.run("uv", "run", "ruff", "check", ".", external=True)
@@ -17,3 +23,12 @@ def typecheck(session: nox.Session) -> None:
 def tests(session: nox.Session) -> None:
   """Run the test suite."""
   session.run("uv", "run", "pytest", *session.posargs, external=True)
+
+
+@nox.session(name="all")
+def run_all(session: nox.Session) -> None:
+  """Run formatting, linting, type checks, and tests."""
+  session.notify("format")
+  session.notify("lint")
+  session.notify("typecheck")
+  session.notify("tests")


### PR DESCRIPTION
## Summary
- add new `format` session running Pyink
- add an `all` session that calls `format`, `lint`, `typecheck`, and `tests`
- document the new sessions in README and AGENTS

## Testing
- `uv run pyink .`
- `uv run ruff check . --fix`
- `uv run mypy .`
- `uv run pytest`
- `uv run pre-commit run --files AGENTS.md README.md noxfile.py`


------
https://chatgpt.com/codex/tasks/task_e_686da1dbfd24832f8cd129266320e3cb